### PR TITLE
(#2703#2765) added test for infographic

### DIFF
--- a/cypress/integration/EmbeddedInfographic.feature
+++ b/cypress/integration/EmbeddedInfographic.feature
@@ -1,0 +1,95 @@
+Feature: Content creator wants to associate alt text and caption with an infographic, so a user can see it when the infographic is in any context
+
+    ################MEDIUM TEMPLATE#######################
+
+    Scenario: User is able to see alt text of inline infographic - when alt tag has text (Medium Template)
+        Given user is navigating to "/test/embed-info-med"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                       |
+            | alt          | English alt text.                                                                                           |
+            | caption      | This is my caption.                                                                                         |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/Pediatric-MATCH-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png |
+        And "View and Print Infographic" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png"
+
+
+    Scenario: User is able to see inline infographic on mobile with alt tag (Medium Template)
+        Given user is navigating to "/test/embed-info-med"
+        When screen breakpoint is set to "mobile"
+        Then there should be an infographic with the following
+            | attribute    | value                                                                                                       |
+            | alt          | English alt text.                                                                                           |
+            | caption      | This is my caption.                                                                                         |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/Pediatric-MATCH-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png |
+    #    And "View and Print Infographic" link should not appear
+
+    Scenario: User is able to see alt text of inline infographic - when alt tag has text (Medium Template)
+        Given user is navigating to "/espanol/test-es/embed-info-med-es"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                               |
+            | alt          | Spanish alt text.                                                                                                   |
+            | caption      | This is a spanish caption.                                                                                          |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/pediatric-match-espanol-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png |
+        And "Ver y Imprimir Infografía" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png"
+
+
+    Scenario: User is able to see inline infographic on mobile with alt tag
+        Given user is navigating to "/espanol/test-es/embed-info-med-es"
+        When screen breakpoint is set to "mobile"
+        Then there should be an infographic with the following
+            | attribute    | value                                                                                                               |
+            | alt          | Spanish alt text.                                                                                                   |
+            | caption      | This is a spanish caption.                                                                                          |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/pediatric-match-espanol-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png |
+    #    And "Ver y Imprimir Infografía" link should not appear
+
+
+    #######################LARGE TEMPLATE###########################
+
+    Scenario: User is able to see alt text of inline infographic - when alt tag has text (Large Template)
+        Given user is navigating to "/test/embed-info-lrg"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                       |
+            | alt          | English alt text.                                                                                           |
+            | caption      | This is my caption.                                                                                         |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/Pediatric-MATCH-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png |
+        And "View and Print Infographic" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png"
+
+
+    Scenario: User is able to see inline infographic on mobile with alt tag (Large Template)
+        Given user is navigating to "/test/embed-info-med"
+        When screen breakpoint is set to "mobile"
+        Then there should be an infographic with the following
+            | attribute    | value                                                                                                       |
+            | alt          | English alt text.                                                                                           |
+            | caption      | This is my caption.                                                                                         |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/Pediatric-MATCH-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png |
+    #    And "View and Print Infographic" link should not appear
+
+    Scenario: User is able to see alt text of inline infographic - when alt tag has text (Large Template)
+        Given user is navigating to "/espanol/test-es/embed-info-lrg-es"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                               |
+            | alt          | Spanish alt text.                                                                                                   |
+            | caption      | This is a spanish caption.                                                                                          |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/pediatric-match-espanol-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png |
+        And "Ver y Imprimir Infografía" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png"
+
+
+    Scenario: User is able to see inline infographic on mobile with alt tag -Large template
+        Given user is navigating to "/espanol/test-es/embed-info-lrg-es"
+        When screen breakpoint is set to "mobile"
+        Then there should be an infographic with the following
+            | attribute    | value                                                                                                               |
+            | alt          | Spanish alt text.                                                                                                   |
+            | caption      | This is a spanish caption.                                                                                          |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/pediatric-match-espanol-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png |
+#    And "Ver y Imprimir Infografía" link should not appear
+

--- a/cypress/integration/FullInfographicPage.feature
+++ b/cypress/integration/FullInfographicPage.feature
@@ -1,0 +1,116 @@
+Feature: As I user I want to be able to see full infographic page
+
+    Scenario: Full infographic page with translation without mobile image english
+        Given user is navigating to "/about-nci/organization/nci-at-a-glance"
+        Then language toggle is displayed with the href "/espanol/infografia-nci"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                |
+            | alt          | empty                                                                                                |
+            | caption      | none                                                                                                 |
+            | mobileImage  | none                                                                                                 |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/nci-at-a-glance-enlarge.gif |
+        And "View and Print Infographic" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/nci-at-a-glance-enlarge.gif"
+
+    Scenario: Full infographic page with translation without mobile image english - mobile breakpoint
+        Given user is navigating to "/about-nci/organization/nci-at-a-glance"
+        When screen breakpoint is set to "mobile"
+        Then language toggle is displayed with the href "/espanol/infografia-nci"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                |
+            | caption      | none                                                                                                 |
+            | alt          | empty                                                                                                |
+            | mobileImage  | none                                                                                                 |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/nci-at-a-glance-enlarge.gif |
+    #    And "View and Print Infographic" link should not appear
+
+    Scenario: Full infographic page with translation without mobile image spanish
+        Given user is navigating to "/espanol/infografia-nci"
+        Then language toggle is displayed with the href "/about-nci/organization/nci-at-a-glance"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                            |
+            | caption      | none                                                                                                             |
+            | alt          | empty                                                                                                            |
+            | mobileImage  | none                                                                                                             |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/espanol-nci-at-a-glance-infographic.gif |
+        And "Ver y Imprimir Infografía" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/espanol-nci-at-a-glance-infographic.gif"
+
+    Scenario: Full infographic page with translation without mobile image spanish - Mobile breakpoint
+        Given user is navigating to "/espanol/infografia-nci"
+        When screen breakpoint is set to "mobile"
+        Then language toggle is displayed with the href "/about-nci/organization/nci-at-a-glance"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                            |
+            | caption      | none                                                                                                             |
+            | alt          | empty                                                                                                            |
+            | mobileImage  | none                                                                                                             |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/espanol-nci-at-a-glance-infographic.gif |
+    #    And "View and Print Infographic" link should not appear
+
+    Scenario: Full infographic page without translation without mobile image
+        Given user is navigating to "/about-nci/organization/screen-to-save-infographic"
+        Then language toggle is not displayed
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                                             |
+            | caption      | none                                                                                                                              |
+            | alt          | empty                                                                                                                             |
+            | mobileImage  | none                                                                                                                              |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/cancer-and-the-human-tumor-atlas-network-infographic.png |
+        And "View and Print Infographic" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/cancer-and-the-human-tumor-atlas-network-infographic.png"
+
+    Scenario: Full infographic page without translation without mobile image - mobile breakpoint
+        Given user is navigating to "/about-nci/organization/screen-to-save-infographic"
+        When screen breakpoint is set to "mobile"
+        Then language toggle is not displayed
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                                             |
+            | caption      | none                                                                                                                              |
+            | alt          | empty                                                                                                                             |
+            | mobileImage  | none                                                                                                                              |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/cancer-and-the-human-tumor-atlas-network-infographic.png |
+    #    And "View and Print Infographic" link should not appear
+
+    Scenario: Full translated infographic page with mobile image english
+        Given user is navigating to "/pediatric-match-infographic"
+        Then language toggle is displayed with the href "/espanol/match-infantil-infografia"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                       |
+            | alt          | English alt text.                                                                                           |
+            | caption      | This is my caption.                                                                                         |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/Pediatric-MATCH-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png |
+        And "View and Print Infographic" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png"
+
+    Scenario: Full translated infographic page with mobile image english - mobile breakpoint
+        Given user is navigating to "/pediatric-match-infographic"
+        When screen breakpoint is set to "mobile"
+        Then language toggle is displayed with the href "/espanol/match-infantil-infografia"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                       |
+            | alt          | English alt text.                                                                                           |
+            | caption      | This is my caption.                                                                                         |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/Pediatric-MATCH-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-640x2.png |
+    #    And "View and Print Infographic" link should not appear
+
+    Scenario: Full translated infographic page with mobile image spanish
+        Given user is navigating to "/espanol/match-infantil-infografia"
+        Then language toggle is displayed with the href "/pediatric-match-infographic"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                               |
+            | alt          | Spanish alt text.                                                                                                   |
+            | caption      | This is a spanish caption.                                                                                          |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/pediatric-match-espanol-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png |
+        And "Ver y Imprimir Infografía" link appears below caption text with the href "/sites/default/files/styles/cgov_enlarged/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png"
+
+    Scenario: Full translated infographic page with mobile image spanish - mobile breakpoint
+        Given user is navigating to "/espanol/match-infantil-infografia"
+        When screen breakpoint is set to "mobile"
+        Then language toggle is displayed with the href "/pediatric-match-infographic"
+        And there should be an infographic with the following
+            | attribute    | value                                                                                                               |
+            | alt          | Spanish alt text.                                                                                                   |
+            | caption      | This is a spanish caption.                                                                                          |
+            | mobileImage  | /sites/default/files/styles/cgov_article/public/2020-05/pediatric-match-espanol-enlarge.png                         |
+            | desktopImage | /sites/default/files/styles/cgov_article/public/cgov_infographic/2020-05/Human-Tumor-Atlas-AP-web-spanish-640x2.png |
+#    And "View and Print Infographic" link should not appear

--- a/cypress/integration/common/infographic.js
+++ b/cypress/integration/common/infographic.js
@@ -1,0 +1,119 @@
+/// <reference types="Cypress" />
+import { Then } from "cypress-cucumber-preprocessor/steps";
+
+Then('there should be an infographic at position {int} with the following', (number, dataTable) => {
+    //index of a DOM element representing an image 
+    let index = number - 1;
+
+    for (const { attribute, value } of dataTable.hashes()) {
+        // verify alt attribute of an image
+        if (attribute === 'alt') {
+            if (value === 'empty') {
+                cy.get("figure[class*='centered']").eq(index).find('img').should(($div) => {
+                    const el = $div.get(0);
+                    expect(el.getAttribute('alt').trimEnd()).to.be.equal('');
+                })
+            } else {
+                cy.get("figure[class*='centered']").eq(index).find('img').should(($div) => {
+                    const el = $div.get(0);
+                    expect(el.getAttribute('alt').trimEnd()).to.be.equal(value);
+                })
+            }
+        }
+        // verify image caption text
+        if (attribute === 'caption') {
+            if (value === 'none') {
+                cy.get("figure[class*='centered']").eq(index).find('figcaption div p').should('not.exist');
+            } else {
+                cy.get("figure[class*='centered']").eq(index).find('figcaption div p').should(($div) => {
+                    const el = $div.get(0);
+                    expect(el.innerText).to.be.equal(value);
+                });
+            }
+        }
+        if (attribute === 'mobileImage') {
+            if (value === 'none') {
+                cy.get("figure[class*='centered']").find('picture').should('not.exist');
+            } else {
+                cy.get("figure[class*='centered'] picture").find("source[media='(max-width: 768px)']")
+                    .should('have.attr', 'srcset').and('include', value);
+            }
+        } if (attribute === 'desktopImage') {
+            cy.get("figure[class*='centered']").find('img').should('have.attr', 'src').and('include', value);
+        }
+    }
+
+});
+
+
+Then('{string} link appears below caption text with the href {string}', (linkText, linkHref) => {
+    cy.get("figure[class*='centered']").find('figcaption a').should('have.text', linkText);
+    cy.get("figure[class*='centered']").find('figcaption a').should('have.attr', 'href').and('include', linkHref);
+});
+
+Then('infographic at position {int} has a link {string} with the href {string}', (number, linkText, linkHref) => {
+    console.log(`text ${linkText}`)
+    console.log(number)
+    console.log(linkHref)
+    cy.get("figure[class*='centered']").eq(number - 1).find('figcaption a').invoke('text').should('be.eq', linkText);
+    cy.get("figure[class*='centered']").eq(number - 1).find('figcaption a').should('have.attr', 'href').and('include', linkHref);
+});
+
+
+Then('there should be an infographic with the following', (dataTable) => {
+    for (const { attribute, value } of dataTable.hashes()) {
+        // verify alt attribute of an image
+        if (attribute === 'alt') {
+            if (value === 'empty') {
+                cy.get("figure[class*='centered']").find('img').should(($div) => {
+                    const el = $div.get(0);
+                    expect(el.getAttribute('alt').trimEnd()).to.be.equal('');
+                })
+            } else {
+                cy.get("figure[class*='centered']").find('img').should(($div) => {
+                    const el = $div.get(0);
+                    expect(el.getAttribute('alt').trimEnd()).to.be.equal(value);
+                })
+            }
+        }
+        // verify image caption text
+        if (attribute === 'caption') {
+            if (attribute === 'caption') {
+                if (value === 'none') {
+                    cy.get("figure[class*='centered']").find('figcaption div p').should('not.exist');
+                } else {
+                    cy.get("figure[class*='centered']").find('figcaption div').first().should(($div) => {
+                        const el = $div.get(0);
+                        expect(el.innerText).to.be.equal(value);
+                    })
+                }
+            }
+            //verify srcset of mobile (if present) and desktop image 
+            if (attribute === 'mobileImage') {
+                if (value === 'none') {
+                    cy.get("figure[class*='centered']").find('picture').should('not.exist');
+                } else {
+                    cy.get("figure[class*='centered'] picture").find("source[media='(max-width: 768px)']")
+                        .should('have.attr', 'srcset').and('include', value);
+                }
+            } if (attribute === 'desktopImage') {
+                cy.get("figure[class*='centered']").find('img').should('have.attr', 'src').and('include', value);
+            }
+        }
+    }
+});
+
+Then('{string} link should not appear', (viewAndPrintLink) => {
+    cy.get("figure[class*='centered']").find('figcaption a').should('not.exist');
+});
+
+Then('language toggle is not displayed', () => {
+    cy.get('ul.links').should('not.exist');
+});
+
+Then('language toggle is displayed with the href {string}', (langToggleHref) => {
+    cy.get('ul.links a').should('exist').and('have.attr', 'href').and('be.eq', langToggleHref);
+
+})
+
+


### PR DESCRIPTION
tests for alt and caption, mobile image, view/print link
- large and medium template embedded
- full page infographic with/without mobile image

#2703 https://github.com/NCIOCPL/cgov-digital-platform/issues/2703
#2765 https://github.com/NCIOCPL/cgov-digital-platform/issues/2765