### PR TITLE
(#158) Keeping password secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ The tests use [cypress-cucumber-preprocessor](https://github.com/TheBrainFamily/
 Please add `/// <reference types="Cypress" />` to the top of each JS file to get Cypress intellesense. There is some issue where [the Cypress documentation](https://docs.cypress.io/guides/tooling/intelligent-code-completion.html#Reference-type-declarations-via-jsconfig) is nor working correctly. 
 
 ## Adding credentials
-Please create cypress.env.json file in the root folder and add the following
-{
-  "user_name": "admin",
-  "user_password": "" --> value can be found in the digital_platform slack channel in the topic description/ provided by request
-}
-
+`admin_username` is already provided
+The `admin_password` value needs to be added via command line 
+to open cypress UI console
+`CYPRESS_admin_password=value npx cypress open`
+to run in a headless mode
+`CYPRESS_admin_password=value npx cypress run`
+where value is the password ( can be found in digital-platform slack channel topic )
 ## Running Tests
 1. `npm ci`
-1. `CYPRESS_BASE_URL=https://www-dev-ac.cancer.gov npm test`
+2. `CYPRESS_BASE_URL=https://www-dev-ac.cancer.gov CYPRESS_admin_password=value npx cypress run`
+where value is the password ( can be found in digital-platform slack channel topic )

--- a/cypress.json
+++ b/cypress.json
@@ -10,6 +10,8 @@
   },
   "chromeWebSecurity": true,
   "env": {
-    "trackingServer": ["2o7.net", "metrics.cancer.gov"]
+    "trackingServer": ["2o7.net", "metrics.cancer.gov"],
+    "admin_username": "admin",
+    "admin_password": ""
     }
 }

--- a/cypress/integration/AdminSideCMSTest/AdminSideCMSTest.js
+++ b/cypress/integration/AdminSideCMSTest/AdminSideCMSTest.js
@@ -1,10 +1,15 @@
 /// <reference types="Cypress" />
-import { Given, And, Then } from 'cypress-cucumber-preprocessor/steps';
+import { And, Then } from 'cypress-cucumber-preprocessor/steps';
 
-const username = Cypress.env('user_name');
-const password = Cypress.env('user_password');
+const username = Cypress.env('admin_username');
+const password = Cypress.env('admin_password');
 
 When('user enters credentials', () => {
+    expect(username, 'username was set').to.be.a('string').and.not.be.empty
+    // the password value should not be shown
+     if (typeof password !== 'string' || !password || password === '') {
+      throw new Error('Missing password value, set using CYPRESS_admin_password=...')
+}
     cy.get('input#edit-name').type(username, { log: false });
     cy.get('input#edit-pass').type(password, { log: false });
 });


### PR DESCRIPTION
- updated cypress.json env vars
to have hardcoded username and empty
password
- updated test to validate credentials
and throw error if it was not set up
- updated Readme.md with instructions
Closes #158 