### PR TITLE
(#324) Update DCEG Smoke Test Mega Menu Label

### DIFF
--- a/cypress/e2e/ProductionSmokeTests/$DCEG.feature
+++ b/cypress/e2e/ProductionSmokeTests/$DCEG.feature
@@ -1,10 +1,10 @@
 @smoke
 Feature: Basic checks to ensure production site is up and running
 
-    Scenario Outline: Home page is loading on all sites
+    Scenario: Home page is loading on all sites
         Given user is navigating to "/"
         Then mega menu is displayed
-        And main categories titles are "About DCEG,Our Research,Fellowship & Training,Tools & Resources,News & Events"
+        And main categories titles are "About DCEG,Our Research,Fellowships & Training,Tools & Resources,News & Events"
         And footer is displayed
 
     Scenario Outline: Different contents are loaded on all sites


### PR DESCRIPTION
Description of what is updated: 

DCEG mega menu section updated from Fellowship & Training to Fellowships & Training
remove Outline from a first dceg scenario ( should be just Scenario, not scenario Outline)

@KateMashkinaNIH 