### PR TITLE
(346) fixes site sections drag and drop error

### DIFF
--- a/cypress/e2e/CMS/$SiteSections.feature
+++ b/cypress/e2e/CMS/$SiteSections.feature
@@ -138,28 +138,28 @@ Feature: As a cms user I want to be able to create Site Section to promote Site 
         And page title is "Article to test Site Section"
         And 1 level up section is "Coping with Cancer"
 
-    # Scenario: Drag and drop to reorder children
-    #     Given user is navigating to "/user/login"
-    #     When user enters credentials
-    #     And user clicks "Log in" button
-    #     Then user is logged in and the user name "admin" is displayed in the toolbar
-    #     And the tool bar appears at the top
-    #     When user clicks on "Structure" tab
-    #     And user clicks on "Taxonomy" sub tab
-    #     And user selects "List terms" option from Operations for "Site Sections"
-    #     And user selects "children" link under "Home"
-    #     And user selects "children" link under "About Cancer"
-    #     And user selects "children" link under "Coping with Cancer"
-    #     And browser waits
-    #     And user drags "Test Site Section" item one level down
-    #     And browser waits
-    #     Then user saves the content page
+    Scenario: Drag and drop to reorder children
+        Given user is navigating to "/user/login"
+        When user enters credentials
+        And user clicks "Log in" button
+        Then user is logged in and the user name "admin" is displayed in the toolbar
+        And the tool bar appears at the top
+        When user clicks on "Structure" tab
+        And user clicks on "Taxonomy" sub tab
+        And user selects "List terms" option from Operations for "Site Sections"
+        And user selects "children" link under "Home"
+        And user selects "children" link under "About Cancer"
+        And user selects "children" link under "Coping with Cancer"
+        And browser waits
+        And user drags "Test Site Section" item one level down
+        And browser waits
+        Then user saves the content page
 
-    # Scenario: Verify the new tree order of a site section
-    #     Given user is navigating to the front end site with path "/about-cancer/coping"
-    #     Then the current page is "Coping with Cancer" in left nav
-    #     And browser waits
-    #     And "Nav Label" appears in position 2 in the side menu tree
+    Scenario: Verify the new tree order of a site section
+        Given user is navigating to the front end site with path "/about-cancer/coping"
+        Then the current page is "Coping with Cancer" in left nav
+        And browser waits
+        And "Nav Label" appears in position 2 in the side menu tree
 
     Scenario: Verify pretty url change of a site section and removal of nav label
         Given user is navigating to "/user/login"

--- a/cypress/e2e/CMS/$SiteSections/index.js
+++ b/cypress/e2e/CMS/$SiteSections/index.js
@@ -155,7 +155,7 @@ And('user unchecks {string} checkbox', (checkboxLbl) => {
 
 And('user drags {string} item one level down', (dragLink) => {
     cy.get(`a.menu-item__link:contains("${dragLink}")`).parent().find('a.tabledrag-handle').trigger('mousedown', { which: 1, pageX: 200, pageY: 50 })
-        .trigger('mousemove', { which: 1, clientX: 50, clientY: 50, pageY: 50 })
+        .trigger('mousemove', { which: 1, clientX: 50, clientY: 50, pageY: 100 })
         .trigger('mouseup')
 });
 


### PR DESCRIPTION
Closes #346 , fixes the drag-and-drop error from SiteSections. This feature should now pass all tests. 