### PR TITLE
(#541) Updated Spanish Alt Text Label

### DIFF
--- a/cypress/e2e/CMS/$HomeAndLandingPage.feature
+++ b/cypress/e2e/CMS/$HomeAndLandingPage.feature
@@ -562,7 +562,7 @@ Feature: Home And Landing Page Test Creation of Content
             | heroimagenewstablet  |
             | heroimagenewsmobile  |
         And the "Eliminar" button is displayed beside the text "Hero Banner"
-        And Alternative text field was translated as "Texto alternativo (todos los idiomas)"
+        And Alternative text field was translated as "Texto alternativo"
         And the following sections have title field translated as "Título"
             | section                  |
             | Primary Feature Card     |


### PR DESCRIPTION
Closes #541 

The label for Alternative Text field on Spanish Home & Landing pages has recently been changed from "Texto alternativo (todos los idiomas)" to "Texto alternativo". As a result of this change, the $HomeAndLandingPage.feature test is failing. So we are updating the $HomeAndLandingPage.feature test by replacing "Texto alternativo (todos los idiomas)" with "Texto alternativo" so that all our tests pass. 