### PR TITLE
(#543) Updated the H1 title for the PDQ

### DIFF
--- a/cypress/e2e/ProductionSmokeTests/$GeneralTests.feature
+++ b/cypress/e2e/ProductionSmokeTests/$GeneralTests.feature
@@ -23,13 +23,13 @@ Feature: Basic checks to ensure production site is up and running
         And content is displayed
         And language toggle has a text "<languageToggle>"
         Examples:
-            | url                                                                                              | title                                                                   | languageToggle |
-            | /about-cancer/coping/feelings/relaxation                                                         | Learning to Relax                                                       | Español        |
-            | /news-events/cancer-currents-blog/2020/fda-foundation-one-cancer-liquid-biopsy-expanded-approval | Cancer “Liquid Biopsy” Blood Test Gets Expanded FDA Approval            | Español        |
-            | /research/infrastructure/cancer-centers/find/mayoclinic                                          | Mayo Clinic Cancer Center                                               | none           |
-            | /espanol/tipos/higado/cancer-vias-biliares                                                       | ¿Qué es el cáncer de vías biliares (colangiocarcinoma)?                 | English        |
-            | /types/liver/hp/adult-liver-treatment-pdq                                                        | Adult Primary Liver Cancer Treatment (PDQ®)–Health Professional Version | Español        |
-            | /nano/about/contact/grodzinski-piotr                                                             | Piotr Grodzinski, Ph.D.                                                 | none           |
+            | url                                                                                              | title                                                             | languageToggle |
+            | /about-cancer/coping/feelings/relaxation                                                         | Learning to Relax                                                 | Español        |
+            | /news-events/cancer-currents-blog/2020/fda-foundation-one-cancer-liquid-biopsy-expanded-approval | Cancer “Liquid Biopsy” Blood Test Gets Expanded FDA Approval      | Español        |
+            | /research/infrastructure/cancer-centers/find/mayoclinic                                          | Mayo Clinic Cancer Center                                         | none           |
+            | /espanol/tipos/higado/cancer-vias-biliares                                                       | ¿Qué es el cáncer de vías biliares (colangiocarcinoma)?           | English        |
+            | /types/liver/hp/adult-liver-treatment-pdq                                                        | Primary Liver Cancer Treatment (PDQ®)–Health Professional Version | Español        |
+            | /nano/about/contact/grodzinski-piotr                                                             | Piotr Grodzinski, Ph.D.                                           | none           |
 
     Scenario Outline: Blogs and Press release
         Given user is navigating to "<url>"


### PR DESCRIPTION
Closes #543 
The H1 title has changed in /types/liver/hp/adult-liver-treatment-pdq on Prod from "Adult Primary Liver Cancer Treatment (PDQ®)–Health Professional Version"  to "Primary Liver Cancer Treatment (PDQ®)–Health Professional Version". We have updated the test $GeneralTests.feature to reflect the change.