### PR TITLE
(#549) Ensure all images load

### DIFF
--- a/backstop_data/engine_scripts/playwright/onReady.js
+++ b/backstop_data/engine_scripts/playwright/onReady.js
@@ -1,5 +1,17 @@
 module.exports = async (page, scenario, viewport, isReference, browserContext) => {
   console.log('SCENARIO > ' + scenario.label);
+
+  // Attempt to force all images on the page to load.
+  await page.evaluate(async () => {
+    document.querySelectorAll('[loading="lazy"]').forEach((element) => {
+      element.loading = 'eager';
+    });
+
+    document.querySelectorAll('[decoding="async"]').forEach((element) => {
+      element.decoding = 'sync';
+    });
+  });
+
   await require('./clickAndHoverHelper')(page, scenario);
 
   // add more ready handlers here...


### PR DESCRIPTION
This added in a bit of code onReady that was found on backstopjs issue 57. Basically Drupal sets most images to lazy load which means that are to guaranteed to be downloaded when the page is displayed. I ran it a couple of times and it looks like it mostly works. Broken images because Drupal did not generate them correctly are still a possibility. Also, there need to be some scroll to bottom or something for return to top and CTS where the position of an overlay is changing. However that potential issue is not for this ticket.

Closes #549
