### PR TITLE
(#784) Updated failed Smoke Tests

### DIFF
--- a/cypress/e2e/ProductionSmokeTests/$GeneralTests.feature
+++ b/cypress/e2e/ProductionSmokeTests/$GeneralTests.feature
@@ -26,7 +26,7 @@ Feature: Basic checks to ensure production site is up and running
             | url                                                                                              | title                                                             | languageToggle |
             | /about-cancer/coping/feelings/relaxation                                                         | How to Relax Your Mind and Body                                   | Español        |
             | /news-events/cancer-currents-blog/2020/fda-foundation-one-cancer-liquid-biopsy-expanded-approval | Cancer “Liquid Biopsy” Blood Test Gets Expanded FDA Approval      | Español        |
-            | /research/infrastructure/cancer-centers/find/mayoclinic                                          | Mayo Clinic Cancer Center                                         | none           |
+            | /research/infrastructure/cancer-centers/find/mayoclinic                                          | Mayo Clinic Comprehensive Cancer Center                           | none           |
             | /espanol/tipos/higado/cancer-vias-biliares                                                       | ¿Qué es el cáncer de vías biliares (colangiocarcinoma)?           | English        |
             | /types/liver/hp/adult-liver-treatment-pdq                                                        | Primary Liver Cancer Treatment (PDQ®)–Health Professional Version | Español        |
             | /nano/about/contact/grodzinski-piotr                                                             | Piotr Grodzinski, Ph.D.                                           | none           |

--- a/cypress/e2e/ProductionSmokeTests/$TTC.feature
+++ b/cypress/e2e/ProductionSmokeTests/$TTC.feature
@@ -25,5 +25,5 @@ Feature: Basic checks to ensure TTC production site is up and running
         And the text "We can't find the page you're looking for." is displayed
 
     Scenario: Abstract Details
-        Given user is navigating to "/available-technologies?abstract=TAB-4453"
+        Given user is navigating to "/available-technologies?abstract=TAB-4452"
         Then content is displayed


### PR DESCRIPTION
1. Updated title to "Mayo Clinic Comprehensive Cancer Center" on GeneralTests.feature file for the url /research/infrastructure/cancer-centers/find/mayoclinic
2. Updated TTC Abstract page url /available-technologies?abstract=TAB-4453 to /available-technologies?abstract=TAB-4452 on TTC.feature file