### PR TITLE
(#816) Fixed failed Smoke Tests

### DIFF
--- a/cypress/e2e/ProductionSmokeTests/$GeneralTests.feature
+++ b/cypress/e2e/ProductionSmokeTests/$GeneralTests.feature
@@ -31,16 +31,23 @@ Feature: Basic checks to ensure production site is up and running
             | /types/liver/hp/adult-liver-treatment-pdq                                                        | Primary Liver Cancer Treatment (PDQ®)–Health Professional Version | Español        |
             | /nano/about/contact/grodzinski-piotr                                                             | Piotr Grodzinski, Ph.D.                                           | none           |
 
-    Scenario Outline: Blogs and Press release
+  
+    Scenario Outline: Press release
         Given user is navigating to "<url>"
         And page title is "<title>"
         And the list of posts is displayed
         Examples:
             | url                                          | title                         |
-            | /about-nci/organization/cgh/blog?year=2020   | 2020 - CGH Spotlight Blog     |
             | /news-events/press-releases/2022             | 2022 News Releases            |
             | /news-events/press-releases/2023             | 2023 News Releases            |
             | /espanol/noticias/comunicados-de-prensa/2023 | Comunicados de prensa de 2023 |
+ 
+    
+    Scenario: Blogs
+        Given user is navigating to "/about-nci/organization/cgh/blog?year=2020"
+        And page title is "2020 - CGH Spotlight Blog"
+        And the list of blogs is displayed
+  
 
     Scenario Outline: App modules API's is working
         Given app sends the request "<request>"

--- a/cypress/e2e/ProductionSmokeTests/$GeneralTests/productionTests.js
+++ b/cypress/e2e/ProductionSmokeTests/$GeneralTests/productionTests.js
@@ -47,6 +47,10 @@ And('footer is displayed', () => {
 })
 
 And('the list of posts is displayed', () => {
+    cy.get('.cgdp-dynamic-list span').should('be.visible').and('not.be.empty');
+});
+
+And('the list of blogs is displayed', () => {
     cy.get('.dynamic.list li').should('be.visible').and('not.be.empty');
 });
 


### PR DESCRIPTION
Closes #816 

1) Updated locators for the following URL:
/news-events/press-releases/2022
/news-events/press-releases/2023
/espanol/noticias/comunicados-de-prensa/2023

2) Separated Blog and Press Release Scenarios to the following two different Scenarios: 
    Scenario Outline: Press release
    Scenario: Blogs