### PR TITLE
(#825) Force cypress/request to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,9 +1612,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+      "integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -9225,9 +9225,9 @@
       }
     },
     "@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+      "integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -10407,7 +10407,7 @@
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
       "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "requires": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,10 @@
   "devDependencies": {
     "backstopjs": "^6.0.0",
     "cypress": "^12.7.0"
+  },
+  "overrides": {
+    "cypress": {
+      "@cypress/request": "3.0.0"
+    }
   }
 }


### PR DESCRIPTION
v3 is technically a breaking change so this requires an override.

Closes [#825](https://github.com/NCIOCPL/cgov-digital-platform-acceptance-tests/issues/825)